### PR TITLE
use path.sep for linux compat

### DIFF
--- a/engine/launcher.js
+++ b/engine/launcher.js
@@ -14,7 +14,7 @@ const HOME_DIR = os.homedir();
 const executeInfoText = fs.readFileSync(path.join(HOME_DIR, EXECUTE_INFO_PATH)).toString();
 const executablePath = executeInfoText.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/m)[2];
 
-const parsedPath = executablePath.split('\\');
+const parsedPath = executablePath.split(path.sep);
 const execName = parsedPath[parsedPath.length - 1];
 
 const basePath = parsedPath.slice(0, parsedPath.findIndex(s => s === 'StarCraft II') + 1).join(path.sep);


### PR DESCRIPTION
Launcher couldn't find the correct paths due to a hardcoded windows seperator. 

`path.sep` was being used elsewhere. This PR just extends that to everywhere. 


I tried to fix that newline at the end of the file for this PR, but after about 20 mins, I figured it'd be easier to convince the maintainer to overlook that.... :P